### PR TITLE
Remove plpython3 extension

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,5 @@
-Dockerfile
 .git
+.github
+Dockerfile
+LICENSE
+README.md

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+This project **DOES NOT** follow semver but is based on the version scheme of
+the upstream projects: `<postgresql_version>-<postgis_version>[-<revision>]`.
+
+## [Unreleased]
+
+## [13.3.1-1] - 2023-10-02
+
+### Changed
+
+- Removed the `plpython3` extension. [#]
+
+## [13.3.1] - 2023-09-10
+
+Initial release.

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,5 @@ LABEL author="PeopleForBikes" \
 RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
   postgresql-13-pgrouting \
-  postgresql-plpython3-13 \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
The plpython extension is not needed anymore, therefore it was removed
from the Docker image.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
